### PR TITLE
Fix filter method when a column has no values

### DIFF
--- a/cereslib/dfutils/filter.py
+++ b/cereslib/dfutils/filter.py
@@ -20,8 +20,6 @@
 #
 
 
-import pandas
-
 class Filter(object):
     """ Class that filters information for a given dataset.
 
@@ -36,6 +34,7 @@ class Filter(object):
     certain commits that follow some pattern such as merges
     or automatically generated ones.
     """
+
 
 class FilterRows(Filter):
     """ Class used to filter those files that are part of a merge
@@ -65,10 +64,12 @@ class FilterRows(Filter):
 
         for column in columns:
             if column not in self.data.columns:
-                return self.data
+                raise ValueError("Column %s not in DataFrame columns: %s" % (column, list(self.data)))
 
         for column in columns:
-            self.data = self.data[self.data[column] != value]
+            # Filtering on empty data series doesn't make sense at all and also would raise an error
+            column_len = len(self.data[column])
+            if column_len > 0 and column_len != self.data[column].isnull().sum():
+                self.data = self.data[self.data[column] != value]
 
         return self.data
-

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2018 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#     Alberto Pérez García-Plaza <alpgarcia@bitergia.com>
+#
+
+import pandas
+import sys
+import unittest
+
+if '..' not in sys.path:
+    sys.path.insert(0, '..')
+
+from cereslib.dfutils.filter import FilterRows
+
+
+class TestFilter(unittest.TestCase):
+    """ Unit tests for Filter class
+    """
+
+    def test_filter_rows(self):
+        """ Test several cases for filtering rows by column value
+        """
+
+        # One column, values of different types
+        df = pandas.DataFrame()
+        filepaths = ['', None, '-', '/file/path', 1, True, pandas.np.nan, '-', [1, 2]]
+        df["filepath"] = filepaths
+        data_filtered = FilterRows(df)
+        df = data_filtered.filter_(["filepath"], "-")
+
+        self.assertEqual(len(df), 7)
+
+        # One empty column
+        df = pandas.DataFrame()
+        df["filepath"] = []
+        data_filtered = FilterRows(df)
+        df = data_filtered.filter_(["filepath"], "-")
+
+        self.assertEqual(len(df), 0)
+
+        # Several columns and just one empty
+        df = pandas.DataFrame()
+        df["filepath"] = []
+        df["name"] = ["name", "-", "other", "-"]
+        df["dirname"] = ["dir", "-", "-", "-"]
+        data_filtered = FilterRows(df)
+        df = data_filtered.filter_(["filepath", "name", "dirname"], "-")
+
+        self.assertEqual(len(df), 1)
+
+    def test_column_not_exists(self):
+        """ Test empty dataframe looking for the corresponding ValueError exception
+        """
+        df = pandas.DataFrame()
+        data_filtered = FilterRows(df)
+        with self.assertRaisesRegex(ValueError, "Column filepath not in DataFrame columns: \[\]") as context:
+            data_filtered.filter_(["filepath"], "-")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`filter_` method raises an exception when column is empty
(it has no values or all of them are nan). This change
adds a control flow for that situation together with
corresponding tests.