### PR TITLE
[enrich] Prepend file dir paths with slash

### DIFF
--- a/cereslib/enrich/enrich.py
+++ b/cereslib/enrich/enrich.py
@@ -185,6 +185,11 @@ class FilePath(Enrich):
         self.data['file_dir_name'] = self.data[column].str.replace('/+', '/')
         self.data['file_dir_name'] = \
             self.data.apply(lambda row:
+                            row.file_dir_name if row.file_dir_name.startswith('/')
+                            else '/' + row.file_dir_name,
+                            axis=1)
+        self.data['file_dir_name'] = \
+            self.data.apply(lambda row:
                             row.file_dir_name[:row.file_dir_name.rfind('/') + 1],
                             axis=1)
 

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -116,7 +116,7 @@ class TestEnrich(unittest.TestCase):
         file_1['filepath'] = 'file.txt'
         file_1['file_name'] = 'file.txt'
         file_1['file_ext'] = 'txt'
-        file_1['file_dir_name'] = ''
+        file_1['file_dir_name'] = '/'
         file_1['file_path_list'] = ['file.txt']
         file_2['filepath'] = '/foo/bar'
         file_2['file_name'] = 'bar'


### PR DESCRIPTION
This code prepends to the values of the attribute `file_dir_name` a slash, thus avoiding to have directories with empty values.