### PR TITLE
[cereslib] Update license info

### DIFF
--- a/cereslib/__init__.py
+++ b/cereslib/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2018 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/cereslib/dfutils/filter.py
+++ b/cereslib/dfutils/filter.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
-# Copyright (C) 2016 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Daniel Izquierdo Cortazar <dizquierdo@bitergia.com>

--- a/cereslib/dfutils/format.py
+++ b/cereslib/dfutils/format.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
-# Copyright (C) 2016 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Daniel Izquierdo Cortazar <dizquierdo@bitergia.com>

--- a/cereslib/enrich/enrich.py
+++ b/cereslib/enrich/enrich.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
-# Copyright (C) 2016 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Daniel Izquierdo Cortazar <dizquierdo@bitergia.com>

--- a/cereslib/events/events.py
+++ b/cereslib/events/events.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
-# Copyright (C) 2016 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Daniel Izquierdo Cortazar <dizquierdo@bitergia.com>

--- a/examples/areas_code.py
+++ b/examples/areas_code.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
-# Copyright (C) 2017 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Daniel Izquierdo Cortazar <dizquierdo@bitergia.com>

--- a/examples/engines_analysis.py
+++ b/examples/engines_analysis.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
-# Copyright (C) 2017 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Daniel Izquierdo Cortazar <dizquierdo@bitergia.com>

--- a/examples/openstack_gender.py
+++ b/examples/openstack_gender.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
-# Copyright (C) 2017 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #   Daniel Izquierdo Cortazar <dizquierdo@bitergia.com>

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2018 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2015-2018 Bitergia
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Daniel Izquierdo <dizquierdo@bitergia.com>

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2016 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Daniel Izquierdo <dizquierdo@bitergia.com>

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2018 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Alberto Pérez García-Plaza <alpgarcia@bitergia.com>

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2016 Bitergia
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,8 +13,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #     Daniel Izquierdo <dizquierdo@bitergia.com>


### PR DESCRIPTION
This code updates the license info based on the content of https://www.gnu.org/licenses/gpl-3.0.html. Furthermore it also updates the `shebang` line of certain files.