### PR TITLE
[setup] Reduce constraints on dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<=1.14.2
-scipy<=1.1.0
-six<=1.12.0
+numpy
+scipy
+six
 -e git+https://github.com/chaoss/grimoirelab-elk/#egg=grimoirelab-elk

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(name="cereslib",
       ],
       install_requires=[
           'grimoire-elk>=0.30.23',
-          'numpy<=1.14.2',
-          'scipy<=1.1.0',
-          'six<=1.12.0'
+          'numpy',
+          'scipy',
+          'six'
       ],
       zip_safe=False)


### PR DESCRIPTION
Having numpy and scipy restricted caused some trouble with Python 3.7 (because there are no ready to install versions for those libraries for Python 3.7), so I'm releasing their constraints on old versions.

Although six is not causing trouble, I'm also releasing its limit on dependencies, preventing for the future.

Signed-off-by: Jesus M. Gonzalez-Barahona <jgb@gsyc.es>