### PR TITLE
[test] Add test for Git events

### DIFF
--- a/examples/areas_code.py
+++ b/examples/areas_code.py
@@ -182,20 +182,20 @@ def parse_es_section(parser, es_section):
     connection_input = "https://" + user + ":" + password + "@" + host + ":"\
                        + port + "/" + path
     print("Input ES:", connection_input)
-    es_read = Elasticsearch([connection_input], use_ssl=True, verity_certs=True,
-                            ca_cert=certifi.where(), timeout=100)
-
+    # es_read = Elasticsearch([connection_input], use_ssl=True, verity_certs=False,
+    #                         ca_cert=certifi.where(), timeout=100)
+    es_read = Elasticsearch(['https://admin:admin@localhost:9200/'], verify_certs=False)
     credentials = ""
     if user_output:
         credentials = user_output + ":" + password_output + "@"
 
-    connection_output = "http://" + credentials + host_output + ":"\
+    connection_output = "https://" + credentials + host_output + ":"\
                         + port_output + "/" + path_output
-    # es_write = Elasticsearch([connection_output], use_ssl=True,
-    #                           verity_certs=True, ca_cert=certifi.where(),
+    # es_write = Elasticsearch([connection_output], use_ssl=False,
+    #                           verity_certs=False, ca_cert=certifi.where(),
     #                           scroll='300m', timeout=100)
+    es_write = Elasticsearch(['https://admin:admin@localhost:9200/'], verify_certs=False)
     print("Output ES:", connection_output)
-    es_write = Elasticsearch([connection_output])
 
     return ES_config(es_read=es_read, es_write=es_write,
                      es_read_git_index=es_read_git_index,
@@ -276,7 +276,6 @@ def eventize_and_enrich(commits, git_enrich):
     logging.info("New commits: " + str(len(commits)))
 
     # Create events from commits
-    # TODO add tests for eventize method
     git_events = Git(commits, git_enrich)
     events_df = git_events.eventize(2)
 

--- a/tests/data/events/git.json
+++ b/tests/data/events/git.json
@@ -1,0 +1,321 @@
+[
+  {
+  "backend_name": "Git",
+  "backend_version": "0.12.0",
+  "perceval_version": "0.13.0",
+  "timestamp": 1586671647.853214,
+  "origin": "https://github.com/chaoss/grimoirelab-perceval",
+  "uuid": "e2c35296ba4bd579c65a94a7c7bdfc6e96434200",
+  "updated_on": 1459351209,
+  "classified_fields_filtered": null,
+  "category": "commit",
+  "search_fields": {
+    "item_id": "1461ef5b5de821a0bf3c4542589a96e90a959718"
+  },
+  "tag": "https://github.com/chaoss/grimoirelab-perceval",
+  "data": {
+    "commit": "1461ef5b5de821a0bf3c4542589a96e90a959718",
+    "parents": [
+      "8ea5457766ab9fe699796b8fa937df607a5a8bbc"
+    ],
+    "refs": [],
+    "Author": "Santiago Dueñas <sduenas@bitergia.com>",
+    "AuthorDate": "Wed Mar 30 17:20:09 2016 +0200",
+    "Commit": "Santiago Dueñas <sduenas@bitergia.com>",
+    "CommitDate": "Wed Mar 30 17:20:09 2016 +0200",
+    "message": "[utils] Fix wrong timezone in unixtime_to_datetime()\n\nFunction datetime.datetime.fromtimestamp() creates a\nnew datetime object from an epoch value but using\nthe timezone of the system. Replacing this function\nby datetime.datetime.utcfromtimestamp() returns\na datetime with UTC timezone.",
+    "files": [
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "5b316a5",
+          "1238aa1"
+        ],
+        "action": "M",
+        "file": "perceval/utils.py",
+        "added": "1",
+        "removed": "1"
+      },
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "ef476d2",
+          "6cda5f6"
+        ],
+        "action": "M",
+        "file": "tests/test_utils.py",
+        "added": "2",
+        "removed": "2"
+      }
+    ]
+  },
+  "metadata__updated_on": "2016-03-30T15:20:09+00:00",
+  "metadata__timestamp": "2020-04-12T06:07:27.853214+00:00"
+  },
+  {
+  "backend_name": "Git",
+  "backend_version": "0.12.0",
+  "perceval_version": "0.13.0",
+  "timestamp": 1586671647.854481,
+  "origin": "https://github.com/chaoss/grimoirelab-perceval",
+  "uuid": "8b1ba211339e6c3730182b862a0ab53a7e0b4838",
+  "updated_on": 1459853963,
+  "classified_fields_filtered": null,
+  "category": "commit",
+  "search_fields": {
+    "item_id": "8735246751ddefd007d4dd647d3cbe7aeac6919e"
+    },
+  "tag": "https://github.com/chaoss/grimoirelab-perceval",
+  "data": {
+    "commit": "8735246751ddefd007d4dd647d3cbe7aeac6919e",
+    "parents": [
+      "2eec2cf82d794ea0d0e7c74223e88c3dee78cc5c"
+    ],
+    "refs": [],
+    "Author": "Santiago Dueñas <sduenas@bitergia.com>",
+    "AuthorDate": "Tue Apr 5 12:59:23 2016 +0200",
+    "Commit": "Santiago Dueñas <sduenas@bitergia.com>",
+    "CommitDate": "Tue Apr 5 12:59:23 2016 +0200",
+    "message": "[utils] Parse dates with parentheses sections\n\nSo far, dates like 'Wed, 26 Oct 2005 15:20:32 -0100 (GMT+1)'\nraised an error when they were parsed due the parentheses\nsection. This patch removes the section making the parsing\npossible.",
+    "files": [
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "1238aa1",
+          "51aaecd"
+        ],
+        "action": "M",
+        "file": "perceval/utils.py",
+        "added": "5",
+        "removed": "0"
+      },
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "6cda5f6",
+          "1700724"
+        ],
+        "action": "M",
+        "file": "tests/test_utils.py",
+        "added": "12",
+        "removed": "0"
+      }
+    ]
+  },
+  "metadata__updated_on": "2016-04-05T10:59:23+00:00",
+  "metadata__timestamp": "2020-04-12T06:07:27.854481+00:00"
+  },
+  {
+  "backend_name": "Git",
+  "backend_version": "0.12.0",
+  "perceval_version": "0.13.0",
+  "timestamp": 1586671647.855509,
+  "origin": "https://github.com/chaoss/grimoirelab-perceval",
+  "uuid": "6d80881abfb62d37539d0a756d7372607c1bbcfa",
+  "updated_on": 1459985324,
+  "classified_fields_filtered": null,
+  "category": "commit",
+  "search_fields": {
+    "item_id": "53efc14001c806f0452a8fa3c38a640075515561"
+  },
+  "tag": "https://github.com/chaoss/grimoirelab-perceval",
+  "data": {
+    "commit": "53efc14001c806f0452a8fa3c38a640075515561",
+    "parents": [
+      "13a21eba7965f48c472f68df5cb3c50942fbe610"
+    ],
+    "refs": [],
+    "Author": "Santiago Dueñas <sduenas@bitergia.com>",
+    "AuthorDate": "Thu Apr 7 01:28:44 2016 +0200",
+    "Commit": "Santiago Dueñas <sduenas@bitergia.com>",
+    "CommitDate": "Thu Apr 7 01:28:44 2016 +0200",
+    "message": "[mbox] Add option to retrieve messages since a given date\nThe backend still parses the full mbox but ignores those\nmessages sent before the given date.",
+    "files": [
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "b099a0a",
+          "36cb216"
+        ],
+        "action": "M",
+        "file": "perceval/backends/mbox.py",
+        "added": "26",
+        "removed": "9"
+      },
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "6dd833e",
+          "14357ef"
+        ],
+        "action": "M",
+        "file": "tests/test_mbox.py",
+        "added": "24",
+        "removed": "0"
+      }
+    ]
+  },
+  "metadata__updated_on": "2016-04-06T23:28:44+00:00",
+  "metadata__timestamp": "2020-04-12T06:07:27.855509+00:00"
+  },
+  {
+  "backend_name": "Git",
+  "backend_version": "0.12.0",
+  "perceval_version": "0.13.0",
+  "timestamp": 1586671647.857199,
+  "origin": "https://github.com/chaoss/grimoirelab-perceval",
+  "uuid": "efd3d4c33e787ea4f3e2c8c888628b7765f6e881",
+  "updated_on": 1461606895,
+  "classified_fields_filtered": null,
+  "category": "commit",
+  "search_fields": {
+    "item_id": "f318f1c1745b80e821c7f36459fa96194195c078"
+  },
+  "tag": "https://github.com/chaoss/grimoirelab-perceval",
+  "data": {
+    "commit": "f318f1c1745b80e821c7f36459fa96194195c078",
+    "parents": [
+      "9cd36888ded8a7524d9293a2af0d1bf89b8e9e45"
+    ],
+    "refs": [],
+    "Author": "Santiago Dueñas <sduenas@bitergia.com>",
+    "AuthorDate": "Mon Apr 25 19:50:56 2016 +0200",
+    "Commit": "Santiago Dueñas <sduenas@bitergia.com>",
+    "CommitDate": "Mon Apr 25 19:54:55 2016 +0200",
+    "message": "[backend] Add option to set the origin value",
+    "files": [
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "aef6af7",
+          "51b7948"
+        ],
+        "action": "M",
+        "file": "perceval/backend.py",
+        "added": "2",
+        "removed": "0"
+      },
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "3f73216",
+          "f94c229"
+        ],
+        "action": "M",
+        "file": "tests/test_backend.py",
+        "added": "2",
+        "removed": "1"
+      }
+    ]
+  },
+  "metadata__updated_on": "2016-04-25T17:54:55+00:00",
+  "metadata__timestamp": "2020-04-12T06:07:27.857199+00:00"
+  },
+  {
+  "backend_name": "Git",
+  "backend_version": "0.12.0",
+  "perceval_version": "0.13.0",
+  "timestamp": 1586671647.859997,
+  "origin": "https://github.com/chaoss/grimoirelab-perceval",
+  "uuid": "c3c995de9b6605f730da81b431cb00bcfe795428",
+  "updated_on": 1461799972,
+  "classified_fields_filtered": null,
+  "category": "commit",
+  "search_fields": {
+    "item_id": "8612ac3b527991d3c6c87e9147425f78bb590d17"
+  },
+  "tag": "https://github.com/chaoss/grimoirelab-perceval",
+  "data": {
+    "commit": "8612ac3b527991d3c6c87e9147425f78bb590d17",
+    "parents": [
+      "91ad3823f59508238fe34adbdf27ed12d56cf21e"
+    ],
+    "refs": [],
+    "Author": "Alvaro del Castillo <acs@bitergia.com>",
+    "AuthorDate": "Tue Apr 26 14:44:48 2016 +0200",
+    "Commit": "Santiago Dueñas <sduenas@bitergia.com>",
+    "CommitDate": "Thu Apr 28 01:32:52 2016 +0200",
+    "message": "[github] Improve logs when rate limit is reached.",
+    "files": [
+      {
+        "modes": [
+          "100644",
+          "100644"
+        ],
+        "indexes": [
+          "27505ea",
+          "b26a702"
+        ],
+        "action": "M",
+        "file": "perceval/backends/github.py",
+        "added": "2",
+        "removed": "2"
+      }
+    ]
+  },
+  "metadata__updated_on": "2016-04-27T23:32:52+00:00",
+  "metadata__timestamp": "2020-04-12T06:07:27.859997+00:00"
+  },
+  {
+  "backend_name": "Git",
+  "backend_version": "0.12.0",
+  "perceval_version": "0.13.0",
+  "timestamp": 1586671647.860489,
+  "origin": "https://github.com/chaoss/grimoirelab-perceval",
+  "uuid": "f82b458a517b1ac5f7027bb987747bbd18206a08",
+  "updated_on": 1461800288,
+  "classified_fields_filtered": null,
+  "category": "commit",
+  "search_fields": {
+    "item_id": "106b206956976dbc02604157963493a3eea920b9"
+  },
+  "tag": "https://github.com/chaoss/grimoirelab-perceval",
+  "data": {
+    "commit": "106b206956976dbc02604157963493a3eea920b9",
+    "parents": [
+      "bc2275f82ce494d10985ea5539cfae5a1fbfce31",
+      "3e6a60a4923c63bc1de993f844c3b81c5c7c4d54"
+    ],
+    "refs": [],
+    "Merge": "bc2275f 3e6a60a",
+    "Author": "Santiago Dueñas <sduenas@bitergia.com>",
+    "AuthorDate": "Thu Apr 28 01:38:08 2016 +0200",
+    "Commit": "Santiago Dueñas <sduenas@bitergia.com>",
+    "CommitDate": "Thu Apr 28 01:38:08 2016 +0200",
+    "message": "Merge branch 'githug-rate' of 'git://github.com/acs/perceval.git'",
+    "files": [
+      {
+        "file": "perceval/backends/github.py",
+        "added": "59",
+        "removed": "23"
+      }
+    ]
+  },
+  "metadata__updated_on": "2016-04-27T23:38:08+00:00",
+  "metadata__timestamp": "2020-04-12T06:07:27.860489+00:00"
+  }
+]

--- a/tests/data/projects_map.json
+++ b/tests/data/projects_map.json
@@ -1,0 +1,7 @@
+{
+  "perceval": {
+    "git": [
+      "https://github.com/chaoss/grimoirelab-perceval"
+    ]
+  }
+}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Daniel Izquierdo <dizquierdo@bitergia.com>
+#     Alberto Perez <alpgarcia@bitergia.com>
+#
+
+import os
+import pandas
+import sys
+import unittest
+
+if '..' not in sys.path:
+    sys.path.insert(0, '..')
+
+import json
+
+from cereslib.events.events import Git
+
+from grimoire_elk.utils import get_connectors
+
+
+class TestEvents(unittest.TestCase):
+    """ Unit tests for Enrich classes
+    """
+
+    def setUp(self):
+        self.__tests_dir = os.path.dirname(os.path.realpath(__file__))
+        self.__events_dir = os.path.join(self.__tests_dir, "data/events/")
+        self.connectors = get_connectors()
+
+    def test_GitEvents(self):
+        """ Test several cases for the PairProgramming class
+        """
+
+        connector = "git"
+
+        with open(os.path.join(self.__events_dir, connector + ".json")) as f:
+            items = json.load(f)
+
+        enrich_backend = self.connectors[connector][2](json_projects_map="./data/projects_map.json")
+        enrich_backend.sortinghat = True
+        events = Git(items, enrich_backend)
+
+        events_df = events.eventize(1)
+
+        self.assertFalse(events_df.empty)
+        self.assertEqual(len(events_df), 6)
+        self.assertEqual(len(events_df.columns), 28)
+        self.assertIn("metadata__timestamp", events_df)
+        self.assertIn("metadata__updated_on", events_df)
+        self.assertIn("metadata__enriched_on", events_df)
+        self.assertIn("grimoire_creation_date", events_df)
+        self.assertIn("project", events_df)
+        self.assertIn("project_1", events_df)
+        self.assertIn("perceval_uuid", events_df)
+        self.assertIn("author_id", events_df)
+        self.assertIn("author_org_name", events_df)
+        self.assertIn("author_name", events_df)
+        self.assertIn("author_uuid", events_df)
+        self.assertIn("author_domain", events_df)
+        self.assertIn("author_user_name", events_df)
+        self.assertIn("author_bot", events_df)
+        self.assertIn("author_multi_org_names", events_df)
+        self.assertIn("id", events_df)
+        self.assertIn("date", events_df)
+        self.assertIn("owner", events_df)
+        self.assertIn("committer", events_df)
+        self.assertIn("committer_date", events_df)
+        self.assertIn("repository", events_df)
+        self.assertIn("message", events_df)
+        self.assertIn("hash", events_df)
+        self.assertIn("git_author_domain", events_df)
+
+        events_df = events.eventize(2)
+
+        self.assertFalse(events_df.empty)
+        self.assertEqual(len(events_df), 10)
+        self.assertEqual(len(events_df.columns), 30)
+        self.assertIn("eventtype", events_df)
+        self.assertIn("date", events_df)
+        self.assertIn("owner", events_df)
+        self.assertIn("committer", events_df)
+        self.assertIn("committer_date", events_df)
+        self.assertIn("repository", events_df)
+        self.assertIn("message", events_df)
+        self.assertIn("hash", events_df)
+        self.assertIn("git_author_domain", events_df)
+        self.assertIn("files", events_df)
+        self.assertIn("fileaction", events_df)
+        self.assertIn("filepath", events_df)
+        self.assertIn("addedlines", events_df)
+        self.assertIn("removedlines", events_df)


### PR DESCRIPTION
This PR adds tests for eventize method for Git backend.
Test data and projects map file has been added.

Based on a TODO here:
https://github.com/chaoss/grimoirelab-cereslib/blob/2f6ac3d15bcd4d963e8c3632852021e0c1353acc/examples/areas_code.py#L279

Signed-off-by: Nitish Gupta <imnitish.ng@gmail.com>