### PR TITLE
Constraint numpy deps and fix flake8

### DIFF
--- a/cereslib/enrich/enrich.py
+++ b/cereslib/enrich/enrich.py
@@ -257,9 +257,9 @@ class MessageLogFlag(Enrich):
         flags = []
         values = []
         lines = body.split('\n')
-        for l in lines:
+        for line in lines:
             for name in self.FLAGS_REGEX:
-                m = re.match(self.FLAGS_REGEX[name], l)
+                m = re.match(self.FLAGS_REGEX[name], line)
 
                 if m:
                     flags.append(name)
@@ -343,9 +343,9 @@ class EmailFlag(Enrich):
         flags = []
         values = []
         lines = body.split('\n')
-        for l in lines:
+        for line in lines:
             for name in self.FLAGS_REGEX:
-                m = re.match(self.FLAGS_REGEX[name], l)
+                m = re.match(self.FLAGS_REGEX[name], line)
 
                 if m:
                     flags.append(name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<=1.18.3
 scipy
 six
 -e git+https://github.com/chaoss/grimoirelab-elk/#egg=grimoirelab-elk

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name="cereslib",
       ],
       install_requires=[
           'grimoire-elk>=0.30.23',
-          'numpy',
+          'numpy<=1.18.3',
           'scipy',
           'six'
       ],


### PR DESCRIPTION
The numpy deps is constrainted to <= 1.18.3 due to a failure in building the docker image for grimoirelab in docker, where the numpy version is 1.19.0rc1. Furthermore, 2 flake8 E741 ambiguous variable name errors are fixed. They didn't appear before since the flake8 version in Travis wasn't the latest one.

