### PR TITLE
[poetry] Allow Grimoirelab prereleases in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ numpy = "<=1.18.3"
 six = "^1.16.0"
 scipy = "^1.5"
 pandas = ">=0.22.0,<=0.25.3"
-grimoirelab-toolkit = ">=0.3"
+grimoirelab-toolkit = { version = ">=0.3", allow-prereleases = true }
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"


### PR DESCRIPTION
This commit updates the dependencies of this package and includes the `allow-prerelease` option for all grimoirelab dependencies.
