### PR TITLE
[actions] Include SHA version of the action used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,14 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
       - name: Download distribution artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
         with:
           name: cereslib-dist
           path: dist
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dev dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
 
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install and set up Poetry


### PR DESCRIPTION
This commit updates the version number of the actions being used. Now they will use the commit SHA of a released action version because it is the best for stability and security.

Signed-off-by: Jose Javier Merchante <jjmerchante@bitergia.com>