### PR TITLE
Add more file extensions to FileType method

### DIFF
--- a/cereslib/enrich/enrich.py
+++ b/cereslib/enrich/enrich.py
@@ -129,7 +129,8 @@ class FileType(Enrich):
 
         # Insert 'Code' only in those rows that are
         # detected as being source code thanks to its extension
-        reg = "\.c$|\.h$|\.cc$|\.cpp$|\.cxx$|\.c\+\+$|\.cp$|\.py$|\.js$|\.java$|\.rs$|\.go$"
+        reg = "\.bazel$|\.bazelrc$|\.bzl$|\.c$|\.cc$|\.cp$|\.cpp$|\.cxx$|\.c\+\+$|" +\
+              "\.go$|\.h$|\.js$|\.mjs$|\.java$|\.py$|\.rs$|\.sh$|\.tf$|\.ts$"
         self.data.loc[self.data[column].str.contains(reg), 'filetype'] = 'Code'
 
         return self.data

--- a/releases/unreleased/add-more-file-extensions-to-filetype-method.yml
+++ b/releases/unreleased/add-more-file-extensions-to-filetype-method.yml
@@ -1,0 +1,9 @@
+---
+title: Support for more languages and file types
+category: added
+author: Luis Cañas-Díaz <lcanas@bitergia.com>
+issue: null
+notes: |
+  The library is able to detect the new file formats
+  and language formats. This list includes JavaScript,
+  TypeScript, Terraform, among others.


### PR DESCRIPTION
Changes modify the regular expression with file extensions to include the following languages:
  - TypeScript (.ts)
  - JavaScrit (.mjs)
  - Bazel (.bazel, .bzl and .bazelrc)
  - Shell (.sh)
  - Terraform (.tf)

To make easier the maintenance of the list, the new one is ordered by name.

Signed-off-by: Luis Cañas-Díaz <lcanas@bitergia.com>