### PR TITLE
Remove Python 3.12 from release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download distribution artifact


### PR DESCRIPTION
In the next release, remove Python 3.12 from the tests to facilitate the creation of the release, as it conflicts with the circular dependency of grimoire-elk.