### PR TITLE
Fix invalid escape sequence in regex

### DIFF
--- a/cereslib/enrich/enrich.py
+++ b/cereslib/enrich/enrich.py
@@ -127,8 +127,8 @@ class FileType(Enrich):
 
         # Insert 'Code' only in those rows that are
         # detected as being source code thanks to its extension
-        reg = "\.bazel$|\.bazelrc$|\.bzl$|\.c$|\.cc$|\.cp$|\.cpp$|\.cxx$|\.c\+\+$|" +\
-              "\.go$|\.h$|\.js$|\.mjs$|\.java$|\.py$|\.rs$|\.sh$|\.tf$|\.ts$"
+        reg = r"\.bazel$|\.bazelrc$|\.bzl$|\.c$|\.cc$|\.cp$|\.cpp$|\.cxx$|\.c\+\+$|" +\
+              r"\.go$|\.h$|\.js$|\.mjs$|\.java$|\.py$|\.rs$|\.sh$|\.tf$|\.ts$"
         self.data.loc[self.data[column].str.contains(reg), 'filetype'] = 'Code'
 
         return self.data

--- a/poetry.lock
+++ b/poetry.lock
@@ -499,4 +499,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "51a3b23f0d59ce3a9aa2c7241461b40e9538f1e7fa895a93bff4e78ee1d2c3af"
+content-hash = "7b3eba89735a5232e7962f1ce3db45ba560d8ff577df42b84247da42456cd91c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ scipy = "^1.5"
 pandas = "^2.2"
 grimoirelab-toolkit = { version = ">=0.3", allow-prereleases = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 flake8 = "^7.1.1"
 coverage = "^6.2"
 

--- a/releases/unreleased/invalid-syntax-for-backslashes-in-regex.yml
+++ b/releases/unreleased/invalid-syntax-for-backslashes-in-regex.yml
@@ -1,0 +1,8 @@
+---
+title: Invalid syntax for backslashes in regex
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Fix invalid scape sequence to avoid SyntaxWarning for backslashes
+  in file pattern regex.


### PR DESCRIPTION
Use a raw string to avoid SyntaxWarning for backslashes in file pattern regex.

We had the following warnings in the logs:
```
/.../cereslib/cereslib/enrich/enrich.py:130: SyntaxWarning: invalid escape sequence '\.'
  reg = "\.bazel$|\.bazelrc$|\.bzl$|\.c$|\.cc$|\.cp$|\.cpp$|\.cxx$|\.c\+\+$|" +\
/.../cereslib/cereslib/enrich/enrich.py:131: SyntaxWarning: invalid escape sequence '\.'
  "\.go$|\.h$|\.js$|\.mjs$|\.java$|\.py$|\.rs$|\.sh$|\.tf$|\.ts$"
```

and

```
The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
```